### PR TITLE
Add path prefix to react router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { Button } from 'react-bootstrap';
 import { InfoModal } from './components/info-modal/InfoModal';
 import { Redirect } from 'react-router-dom';
 import pkg from '../package.json'
+import pathPrefix from './helpers/pathPrefix'
 
 interface AppProps {
 
@@ -211,7 +212,7 @@ export default class App extends React.Component<AppProps, AppState> {
     //   throw new Error('IE is not allowed please use Chrome!');
     // }
     if (this.state.Status === "completed") {
-      return <Redirect push to="/confirmation" />;
+      return <Redirect push to={`${pathPrefix}/confirmation`} />;
     }
     if (this.state.Status === "error") {
       return <Redirect push to={

--- a/src/helpers/pathPrefix.js
+++ b/src/helpers/pathPrefix.js
@@ -1,0 +1,7 @@
+let pathPrefix = '';
+if (process.env.REACT_APP_PUBLIC_URL) {
+    const publicUrl = new URL(process.env.REACT_APP_PUBLIC_URL);
+    pathPrefix = publicUrl.pathname;
+}
+
+export default pathPrefix

--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,19 @@ import * as serviceWorker from './serviceWorker';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { ErrorPage } from './components/error-page/ErrorPage';
 
+let pathPrefix = '';
+if (process.env.REACT_APP_PUBLIC_URL) {
+    const publicUrl = new URL(process.env.REACT_APP_PUBLIC_URL);
+    pathPrefix = publicUrl.pathname;
+}
+
 ReactDOM.render(
     <React.StrictMode >
         <BrowserRouter>
             <Switch>
-                <Route exact path='/' component={App} />
-                <Route exact path='/confirmation' component={ConfirmationPage} />
-                <Route exact path='/error' component={ErrorPage} />
+                <Route exact path={pathPrefix + '/'} component={App} />
+                <Route exact path={pathPrefix + '/confirmation'} component={ConfirmationPage} />
+                <Route exact path={pathPrefix + '/error'} component={ErrorPage} />
                 <Route component={ErrorPage} />
             </Switch>
         </BrowserRouter>

--- a/src/index.js
+++ b/src/index.js
@@ -7,20 +7,15 @@ import { ConfirmationPage } from './components/confirmation-page/ConfirmationPag
 import * as serviceWorker from './serviceWorker';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { ErrorPage } from './components/error-page/ErrorPage';
-
-let pathPrefix = '';
-if (process.env.REACT_APP_PUBLIC_URL) {
-    const publicUrl = new URL(process.env.REACT_APP_PUBLIC_URL);
-    pathPrefix = publicUrl.pathname;
-}
+import pathPrefix from './helpers/pathPrefix';
 
 ReactDOM.render(
     <React.StrictMode >
         <BrowserRouter>
             <Switch>
-                <Route exact path={pathPrefix + '/'} component={App} />
-                <Route exact path={pathPrefix + '/confirmation'} component={ConfirmationPage} />
-                <Route exact path={pathPrefix + '/error'} component={ErrorPage} />
+                <Route exact path={`${pathPrefix}/`} component={App} />
+                <Route exact path={`${pathPrefix}/confirmation`} component={ConfirmationPage} />
+                <Route exact path={`${pathPrefix}/error`} component={ErrorPage} />
                 <Route component={ErrorPage} />
             </Switch>
         </BrowserRouter>


### PR DESCRIPTION
React reads the current path from the browser address bar. This patch accounts for path prefixing.